### PR TITLE
Callbacks

### DIFF
--- a/backend/gradio_rerun/__init__.py
+++ b/backend/gradio_rerun/__init__.py
@@ -1,4 +1,4 @@
 
-from .rerun import Rerun
+from .rerun import Rerun, SelectionItem, SelectionItems
 
 __all__ = ['Rerun']

--- a/backend/gradio_rerun/rerun.py
+++ b/backend/gradio_rerun/rerun.py
@@ -115,22 +115,17 @@ class Rerun(Component, StreamingOutput):
             A FileData object containing the image data.
         """
         if value is None:
-            print("[postprocess] value is None")
             return RerunData(root=[])
 
         if isinstance(value, bytes):
-            print("[postprocess] value is bytes")
             if self.streaming:
-                print("[postprocess] value is streaming")
                 return value
-            print("[postprocess] value is byte cache")
             file_path = processing_utils.save_bytes_to_cache(
                 value, "rrd", cache_dir=self.GRADIO_CACHE
             )
             return RerunData(root=[FileData(path=file_path)])
 
         if not isinstance(value, list):
-            print("[postprocess] value is not list")
             value = [value]
 
         def is_url(input: Path | str) -> bool:
@@ -138,7 +133,6 @@ class Rerun(Component, StreamingOutput):
                 return False
             return input.startswith("http://") or input.startswith("https://")
 
-        print("[postprocess] value is is_url:", [is_url(file) for file in value])
         return RerunData(
             root=[
                 FileData(
@@ -165,10 +159,8 @@ class Rerun(Component, StreamingOutput):
             "meta": {"_type": "gradio.FileData"},
         }
         if value is None:
-            print("value is None")
             return None, output_file
 
-        print("returning media stream chunk!")
         return MediaStreamChunk(data=value, duration=0.1, extension=".ts"), output_file
 
     async def combine_stream(
@@ -177,7 +169,6 @@ class Rerun(Component, StreamingOutput):
         desired_output_format: str | None = None,
         only_file=False,
     ) -> RerunData | FileData:
-        print("combining streams!!!")
         return None
 
     def check_streamable(self):

--- a/backend/gradio_rerun/rerun.py
+++ b/backend/gradio_rerun/rerun.py
@@ -2,17 +2,90 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
-import base64
-
-
-from gradio_client import file
-from gradio import processing_utils
+from gradio import EventData, processing_utils
 from gradio.components.base import Component, StreamingOutput
-from gradio.data_classes import GradioRootModel, FileData, MediaStreamChunk
+from gradio.data_classes import FileData, GradioRootModel, MediaStreamChunk
 from gradio.events import EventListener
+
+
+@dataclass
+class EntitySelection:
+    """
+    Selected an entity, or an instance of an entity.
+
+    If the entity was selected within a view, then this also
+    includes the view's name.
+
+    If the entity was selected within a 2D or 3D space view,
+    then this also includes the position.
+    """
+
+    @property
+    def kind(self) -> Literal["entity"]:
+        return "entity"
+
+    entity_path: str
+    instance_id: int | None
+    view_name: str | None
+    position: tuple[int, int, int] | None
+
+
+@dataclass
+class ViewSelection:
+    """Selected a view."""
+
+    @property
+    def kind(self) -> Literal["view"]:
+        return "view"
+
+    view_id: str
+    view_name: str
+
+
+@dataclass
+class ContainerSelection:
+    """Selected a container."""
+
+    @property
+    def kind(self) -> Literal["container"]:
+        return "container"
+
+    container_id: str
+    container_name: str
+
+
+SelectionItem = EntitySelection | ViewSelection | ContainerSelection
+"""A single item in a selection."""
+
+
+def _selection_item_from_json(json: Any) -> SelectionItem:
+    if json["type"] == "entity":
+        position = json.get("position", None)
+        return EntitySelection(
+            entity_path=json["entity_path"],
+            instance_id=json.get("instance_id", None),
+            view_name=json.get("view_name", None),
+            position=(position[0], position[1], position[2]) if position is not None else None,
+        )
+    if json["type"] == "view":
+        return ViewSelection(view_id=json["view_id"], view_name=json["view_name"])
+    if json["type"] == "container":
+        return ContainerSelection(container_id=json["container_id"], container_name=json["container_name"])
+    else:
+        raise NotImplementedError(f"selection item kind {json[type]} is not handled")
+
+
+class SelectionItems(EventData):
+    def __init__(self, target: Any, data: Any):
+        super().__init__(target, data)
+
+        self.items = [
+            _selection_item_from_json(item) for item in data
+        ]
 
 
 class RerunData(GradioRootModel):
@@ -30,7 +103,9 @@ class Rerun(Component, StreamingOutput):
     Creates a Rerun viewer component that can be used to display the output of a Rerun stream.
     """
 
-    EVENTS: list[EventListener | str] = []
+    EVENTS: list[EventListener | str] = [
+        EventListener("selection_change", doc="Fired when the selection changes."),
+    ]
 
     data_model = RerunData
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -4,7 +4,7 @@ import tempfile
 import time
 
 import gradio as gr
-from gradio_rerun import Rerun
+from gradio_rerun import Rerun, SelectionItems
 
 import rerun as rr
 import rerun.blueprint as rrb
@@ -138,6 +138,11 @@ with gr.Blocks() as demo:
             inputs=[x_count, y_count, z_count, pending_cleanup],
             outputs=[viewer],
         )
+
+        def on_selection_change(selection: SelectionItems):
+            print("selection change", selection.items)
+            pass
+        viewer.selection_change(on_selection_change)
 
     with gr.Tab("Hosted RRD"):
         with gr.Row():

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -18,6 +18,7 @@
   import { StatusTracker } from "@gradio/statustracker";
   import type { FileData } from "@gradio/client";
   import type { LoadingStatus } from "@gradio/statustracker";
+  import type { SelectionItem } from "@rerun-io/web-viewer";
 
   interface BinaryStream {
     url: string;
@@ -43,6 +44,7 @@
     upload: never;
     clear: never;
     clear_status: LoadingStatus;
+    selection_change: SelectionItem[];
   }>;
 
   $: height = typeof height === "number" ? `${height}px` : height;
@@ -164,6 +166,7 @@
       setup_panels();
     });
     rr.on("fullscreen", (on) => rr.toggle_panel_overrides(!on));
+    rr.on("selectionchange", (items) => gradio.dispatch("selection_change", items));
 
     rr.start(undefined, ref, {
       hide_welcome_screen: true,

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -57,15 +57,10 @@
   let sentSegments = new Set<string>();
 
   function try_load_value() {
-    console.log("try load value", value, old_value);
     if (rr != undefined && rr.ready) {
-      console.log("should be ready");
       old_value = value;
       if (!Array.isArray(value)) {
-        console.log("not array");
         if (value.is_stream) {
-          console.log("is a stream", value);
-          console.log("url:", value.url);
           // Fetch the HLS playlist
           fetch(value.url)
             .then((response) => {
@@ -97,9 +92,6 @@
                   return;
                 }
                 const currentUrl = uniqueSegmentUrls[processedCount];
-                console.log(
-                  `Fetching segment ${processedCount + 1}/${uniqueSegmentUrls.length}: ${currentUrl}`
-                );
 
                 // Extra check in case the segment was processed in a previous run
                 if (sentSegments.has(currentUrl)) {
@@ -136,14 +128,10 @@
               console.error("Error fetching or processing HLS stream:", error);
             });
         } else {
-          console.log("not a stream", value);
-          console.log("url:", value.url);
           rr.open(value.url);
         }
       } else {
-        console.log("is an array");
         for (const file of value) {
-          console.log("file:", file);
           if (typeof file !== "string") {
             if (file.url) {
               rr.open(file.url);
@@ -191,8 +179,6 @@
 
   $: {
     patched_loading_status = loading_status;
-    console.log("loading status", loading_status?.status);
-    console.log("streaming", streaming);
     if (streaming && patched_loading_status?.status === "generating") {
       patched_loading_status.status = "complete";
     }

--- a/frontend/gradio.config.js
+++ b/frontend/gradio.config.js
@@ -1,5 +1,11 @@
 import tailwindcss from "@tailwindcss/vite";
 import wasm from "vite-plugin-wasm";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from 'node:url';
+import { searchForWorkspaceRoot } from "vite";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // `@rerun-io/web-viewer` uses `new URL("./re_viewer_bg.wasm", import.meta.url)` since 0.17,
 // which does not play well with `vite dev`: https://github.com/rerun-io/rerun/issues/6815
@@ -11,6 +17,18 @@ const hack = () => ({
       optimizeDeps: {
         exclude: process.env.NODE_ENV === "production" ? [] : ["@rerun-io/web-viewer"],
       },
+      server: {
+        fs: {
+          allow: [
+            searchForWorkspaceRoot(process.cwd()),
+            // NOTE: hack to allow `new URL("file://...")` in `web-viewer` when it is a linked package
+            fs.realpathSync(
+              path.join(__dirname, "node_modules", "@rerun-io/web-viewer"),
+            ),
+          ],
+        },
+      },
+
     };
   },
 });


### PR DESCRIPTION
```py
def on_selection_change(selection: SelectionItems):
  print("selection change", selection.items)

def on_time_update(evt: TimeUpdate):
  print("time update", evt.time)

def on_timeline_change(evt: TimelineChange):
  print("timeline change", evt.timeline, evt.time)

viewer.selection_change(on_selection_change)
viewer.time_update(on_time_update)
viewer.timeline_change(on_timeline_change)

```

There seems to be something wrong with `time_update`, it's firing when there is no timeline yet, with `-9223372036854776000`, which is `i64::MIN` cast to an `f64`. Should probably be fixed on the Viewer side, though.

![image](https://github.com/user-attachments/assets/01422e38-b69f-4dce-896b-b0e5b1e3f89d)
